### PR TITLE
Add unified entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,25 @@
 # Suspension
 
-### 프로그램 실행 
-1. bump_generator.py를 실행하여 speedbump stl을 생성합니다.
-2. update_mjcf.py를 실행하여 generated_scene.xml을 생성합니다.
-3. run_sim.py를 실행하여 차량 주행을 확인합니다.
+### 프로그램 실행
+`main.py`가 세 단계를 자동으로 수행합니다. 기본값으로 5개의 속도턱을 생성
+후 배치하고 시뮬레이션을 실행합니다.
 
-### 작업 참고 사항 
-1. bump_generator.py, update_mjcf.py, run_sim.py의 기능을 통합하여 main.py를 다시 작성할 예정입니다.
+```bash
+python main.py [옵션]
+```
+
+주요 옵션은 다음과 같습니다.
+
+| 옵션 | 설명 | 기본값 |
+|------|------|-------|
+|`-n`, `--num-bumps`|배치할 속도턱 개수|`5`|
+|`--seed`|랜덤 시드 (재현성)|`None`|
+|`--torque`|바퀴에 적용할 모터 토크|`100`|
+|`--time`|시뮬레이션 실행 시간(초)|`10`|
+|`--skip-generation`|기존 STL을 사용하고 새로 생성하지 않음|`False`|
+
+### 작업 참고 사항
+1. `main.py`에서 bump 생성, MJCF 갱신, 시뮬레이션 실행을 한 번에 수행합니다.
 2. 현재 PID.py 작업 중입니다. 여러 버전이 존재하여 혼란을 줄 우려가 있어 업로드 하지 않았습니다.
 3. run_sim.py는 PID 적용 및 출력값 수정 등의 이유로 구조가 크게 바뀔 수 있습니다.
 4. Commit Message에 구체적인 역할 정리해두었으니, 확인해주세요! 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,76 @@
+import argparse
+import time
+
+from utils.bump_generator import generate_elliptical_cylinder_stl
+from utils.update_mjcf import insert_stl_to_mjcf
+import mujoco
+import mujoco.viewer
+
+
+def run_simulation(xml_path="models/generated_scene.xml", torque=100.0, sim_time=10.0):
+    """Run mujoco simulation for the given xml scene."""
+    model = mujoco.MjModel.from_xml_path(xml_path)
+    data = mujoco.MjData(model)
+
+    with mujoco.viewer.launch_passive(model, data) as viewer:
+        viewer.cam.lookat[:] = [0, 0, 0.1]
+        viewer.cam.distance = 1.5
+        end_time = data.time + sim_time
+        while viewer.is_running() and data.time < end_time:
+            data.ctrl[model.actuator("fl_motor").id] = torque
+            data.ctrl[model.actuator("fr_motor").id] = torque
+            data.ctrl[model.actuator("rl_motor").id] = torque
+            data.ctrl[model.actuator("rr_motor").id] = torque
+
+            mujoco.mj_step(model, data)
+            viewer.sync()
+            time.sleep(model.opt.timestep)
+
+            acc_z = data.sensordata[model.sensor("accel_z").adr]
+            gyro_pitch = data.sensordata[model.sensor("gyro_pitch").adr]
+            print(
+                f"time={data.time:.3f}s | acc_z={acc_z.item():.3f} m/s² | "
+                f"pitch_rate={gyro_pitch.item():.3f} rad/s"
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate bumps, update scene and run simulation")
+    parser.add_argument(
+        "-n",
+        "--num-bumps",
+        type=int,
+        default=5,
+        help="number of speed bumps to place")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="random seed for bump placement")
+    parser.add_argument(
+        "--torque",
+        type=float,
+        default=100.0,
+        help="motor torque applied to each wheel")
+    parser.add_argument(
+        "--time",
+        type=float,
+        default=10.0,
+        help="simulation duration in seconds")
+    parser.add_argument(
+        "--skip-generation",
+        action="store_true",
+        help="skip creating new bump STL files")
+    args = parser.parse_args()
+
+    if not args.skip_generation:
+        for _ in range(args.num_bumps):
+            generate_elliptical_cylinder_stl()
+
+    insert_stl_to_mjcf(n_bump=args.num_bumps, random_seed=args.seed)
+    run_simulation(torque=args.torque, sim_time=args.time)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `main.py` to handle speedbump generation, MJCF update and running the simulation with CLI options
- document new workflow and options in the README

## Testing
- `python -m py_compile main.py utils/bump_generator.py utils/update_mjcf.py run_sim.py`
- `python main.py --help` *(fails: `ModuleNotFoundError: No module named 'numpy'`)*

------
https://chatgpt.com/codex/tasks/task_e_6853b2f87b708330a8faab8a634ad681