### PR TITLE
Fix sensor attribute syntax for Mujoco

### DIFF
--- a/models/vehicle_model.xml
+++ b/models/vehicle_model.xml
@@ -106,8 +106,9 @@
       <gyro name="gyro_pitch" site="driver_seat"/>
 
       <!-- LiDAR site positions for simulation -->
-      <framepos name="lidar_left_pos" site="lidar_left"/>
-      <framepos name="lidar_right_pos" site="lidar_right"/>
+      <!-- MuJoCo frame sensors use objtype/objname to specify targets -->
+      <framepos name="lidar_left_pos" objtype="site" objname="lidar_left"/>
+      <framepos name="lidar_right_pos" objtype="site" objname="lidar_right"/>
     </sensor>
 
   <actuator>


### PR DESCRIPTION
## Summary
- fix `framepos` definitions in `vehicle_model.xml`

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement mujoco==3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_6853bb6e3530833089f135ed6ee94b2e